### PR TITLE
Loop break for infinite loop problem

### DIFF
--- a/main.go
+++ b/main.go
@@ -170,6 +170,13 @@ func main() {
 			panic(err)
 		}
 
+		// For some reason, either because it's Pleroma or because I have too few toots,
+		// `pg.MaxID` never equals `""` and we get stuck looping forever.  Add a simple
+		// break condition on "no statuses fetched" to avoid the issue.
+		if len(statuses) == 0 {
+			break
+		}
+
 		for _, s := range statuses {
 			err = parseToot(s, stats)
 			if err != nil {


### PR DESCRIPTION
Either my Pleroma instance or my handful of toots causes the status-fetching-with-pagination
to get stuck in an infinite loop. Seems to be a problem in the underlying
mastodon library rather than this code. This is an easier fix for now; to break
out if we fetched no statuses (i.e we ran out.)